### PR TITLE
Fix JSON-RPC 2.0 compatibility

### DIFF
--- a/jsonresults.go
+++ b/jsonresults.go
@@ -451,10 +451,11 @@ func ReadResultCmd(cmd string, message []byte) (Reply, error) {
 	var jsonErr Error
 	var id interface{}
 	err = json.Unmarshal(objmap["error"], &jsonErr)
-	if err != nil {
-		err = fmt.Errorf("error unmarshalling json reply: %v", err)
-		return result, err
-	}
+	// Removed by Jeremy because it freaks out when "error" is missing, even though the JSON-RPC 2.0 spec says it should be missing.
+	//if err != nil {
+	//	err = fmt.Errorf("error unmarshalling json reply: %v", err)
+	//	return result, err
+	//}
 	err = json.Unmarshal(objmap["id"], &id)
 	if err != nil {
 		err = fmt.Errorf("error unmarshalling json reply: %v", err)


### PR DESCRIPTION
Don't return an error when a JSON-RPC result doesn't have an "error" field, because the JSON-RPC 2.0 spec says that it's acceptable for it to be missing sometimes, and Bitcoin Core's bitcoin-cli does not enforce any such check.  This fixes compatibility with bitcoinj-daemon from Sean Gilligan's bitcoinj-addons.

Requesting expedited review+merge so that demoing in Berlin on Friday+Saturday goes more smoothly.
